### PR TITLE
using api router after all middelewares are attached

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -10,13 +10,14 @@ const port: string = env.PORT || '3000';
 
 //const api = require('./api');
 
-app.use('/api', Api);
 app.use(Morgan('combined'));
 app.use(BodyParser.urlencoded({ extended: false }));
 app.use(BodyParser.json());
 app.get('/', (req, res) => {
     res.json({"body": "I got it"});
 });
+
+app.use('/api', Api);
 
 Mongoose.connect('mongodb://localhost:27017/ResourceManagementDB', { useNewUrlParser: true});
 const db = Mongoose.connection;


### PR DESCRIPTION
When you use `api.use` it takes all middlewares attached to the express instance before invocation of the current statement, hence it wouldn't be aware of any successive middlewares. 

Long story short, consider all `app.use` statements as `Queue`, so when you hit your route, there were no body-parser related middleware attached before the router, hence it gives you `undefined`.

In practice, always attach your API Router in the end / after all middlewares.